### PR TITLE
Feature: Updated gamertag parsing

### DIFF
--- a/ruby-app/lib/gamertag.rb
+++ b/ruby-app/lib/gamertag.rb
@@ -1,32 +1,76 @@
-module Gamertag
-  # Snowflakes, and I'm too lazy to improve these.
-  TYPE_1 = /^((ps[4|n]|xb1|xboxone)(([:-]\W*)|\W*))+/i
-  TYPE_2 = /\W*(warlock|titan|teacher)\W*ps[4|n]\W*\s?/i
+require 'strscan'
 
+module Gamertag
   def self.parse(title)
     case title
     when /slacker/i
       'kurzinator'
-    when /psn: palefacex . i'm on gmt/i
-      'PalefaceX'
-    when /software engineer at everlane; psn: esherido/i
-      'Esherido'
     when /NeuronBasher, XB1: Neuron Basher. I also run a little startup called Operable./i
       'NeuronBasher'
     when /XB1: changelog PSN: superdealloc \(CET time\)/i
       'superdealloc'
     when /Software Engineer at Heroku; PSN\/XB1: daneharrigan/i
       'daneharrigan'
-    when /PS4: RebelSenator. Titan main./i
-      'RebelSenator'
-    when /Dean of Students, Xbox One: KaiserHughes/i
-      'KaiserHughes'
-    when TYPE_1
-      title.gsub(TYPE_1, '').chomp(' ')
-    when TYPE_2
-      title.gsub(TYPE_2, '').chomp(' ')
+    when /OwlBoy - Warlock \| PS4/i
+      'OwlBoy'
     else
-      nil
+      parsers = [PlayStationParser, XboxParser]
+      parsers.each do |parser_class|
+        parser = parser_class.new(title)
+        result = parser.extract_gamertag()
+
+        return result unless result.nil?
+      end
+
+      return nil
+    end
+  end
+
+  class GamertagParser
+    attr_reader :text
+
+    def initialize(text)
+      @text = text
+    end
+
+    def extract_gamertag
+      return if self.text.nil?
+
+      scanner = StringScanner.new(self.text)
+      skipped_characters = scanner.skip_until(beginning_regex())
+      return if skipped_characters.nil?
+
+      return scanner.scan_until(ending_regex()).strip().chomp('.')
+    end
+
+    protected
+
+    def beginning_regex
+      raise "beginning_regex not implemented"
+    end
+
+    def ending_regex
+      raise "ending_regex not implemented"
+    end
+  end
+
+  class PlayStationParser < GamertagParser
+    def beginning_regex
+      /PS[4|N]:?\s*-?\s*/i
+    end
+
+    def ending_regex
+      /\.|\s|$/
+    end
+  end
+
+  class XboxParser < GamertagParser
+    def beginning_regex
+      /(XB1|Xbox[\s]+One|xboxone):?\s*/i
+    end
+
+    def ending_regex
+      /\.|$/
     end
   end
 end


### PR DESCRIPTION
This PR adds updated parsing for Xbox and PSN gamertags. It allowed me to remove 6 of the hardcoded gamertags, though there are still a number remaining.

All of the current unit tests pass, though there will be more to do with this feature. For example, we could add parsing for users who have _both_ Xbox and PSN accounts. Perhaps we collect the results of each parser, and return the results in a hash with platforms as the keys?

I haven't used `StringScanner` before so there may be more efficient ways to do what I am doing. In particular, I would like a way to use `scan_until` without _including_ the results of the ending regex (don't include periods or whitespace). Because of this, I am stripping extraneous characters manually, which is a bit messy.

---

**Note:** I have not written Ruby in over a year, please bear with me.