### PR TITLE
Feature: Updated response formats

### DIFF
--- a/ruby-app/Rakefile
+++ b/ruby-app/Rakefile
@@ -1,5 +1,7 @@
 require 'rake/testtask'
 
+task :default => [:test]
+
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList['test/*test.rb', 'test/responses/*test.rb']

--- a/ruby-app/lib/greeting.rb
+++ b/ruby-app/lib/greeting.rb
@@ -1,0 +1,8 @@
+class Greeting
+  GREETINGS = ["Hey", "Hi", "Howdy", "Hello"]
+
+  def self.greet(username)
+    greeting = GREETINGS.sample
+    "#{greeting} #{username}!" unless username.nil?
+  end
+end

--- a/ruby-app/lib/responses/base.rb
+++ b/ruby-app/lib/responses/base.rb
@@ -4,6 +4,11 @@ module Response
       'default response'
     end
 
+    def respond(username, message)
+      greeting = Greeting.greet username
+      "#{greeting} #{message}"
+    end
+
     def attachments
       []
     end

--- a/ruby-app/lib/responses/my_elo.rb
+++ b/ruby-app/lib/responses/my_elo.rb
@@ -16,7 +16,7 @@ module Response
       if slack_user_has_profile_title?
         get_gamertag
       else
-        "Hi <@#{user}> I can't get your gamertag. Please add a profile title. #{change_instructions}"
+        respond user, "I can't get your gamertag. Please add a profile title. #{change_instructions}"
       end
     rescue => e
       TABLE

--- a/ruby-app/lib/responses/my_elo.rb
+++ b/ruby-app/lib/responses/my_elo.rb
@@ -40,7 +40,7 @@ module Response
           get_membership_ids
         else
           title = @slack_user.profile.title.empty? ? 'empty' : "`#{@slack_user.profile.title}`"
-          "Hi <@#{user}> I don't know your gamertag. Your profile title on slack is #{title}. #{change_instructions}"
+          respond user, "I don't know your gamertag. Your profile title on slack is #{title}. #{change_instructions}"
         end
       end
 
@@ -49,7 +49,7 @@ module Response
         @gg_user.get_membership_ids
 
         if @gg_user.membership_ids.empty?
-          "Hi <@#{user}> I couldn’t find you on guardian.gg. Make sure your gamertag is correct."
+          respond user, "I couldn’t find you on guardian.gg. Make sure your gamertag is correct."
         else
           get_elos
         end
@@ -86,6 +86,7 @@ module Response
         else
           domain = 'testing'
         end
+
         "Visit https://#{domain}.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)"
       end
   end

--- a/ruby-app/test/custom_assertions.rb
+++ b/ruby-app/test/custom_assertions.rb
@@ -1,0 +1,17 @@
+require 'minitest/assertions'
+
+module MiniTest::Assertions
+  def assert_response(expected, actual)
+    split_expected = remove_greeting(expected)
+    split_actual = remove_greeting(actual)
+
+    assert_equal split_expected.last, split_actual.last
+  end
+
+  private
+
+  def remove_greeting(message)
+    greeting = message.partition '! '
+    return greeting
+  end
+end

--- a/ruby-app/test/custom_assertions.rb
+++ b/ruby-app/test/custom_assertions.rb
@@ -11,7 +11,6 @@ module MiniTest::Assertions
   private
 
   def remove_greeting(message)
-    greeting = message.partition '! '
-    return greeting
+     message.partition '! '
   end
 end

--- a/ruby-app/test/greeting_test.rb
+++ b/ruby-app/test/greeting_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require_relative '../lib/greeting'
+
+class GreetingTest < MiniTest::Test
+  def test_no_username_provided
+    greeting = Greeting.greet(nil)
+    assert_equal greeting, nil
+  end
+
+  def test_successful_greeting
+    username = "@samsymons"
+    greeting = Greeting.greet username
+
+    assert greeting.end_with?(username + "!")
+  end
+end

--- a/ruby-app/test/responses/my_elo_test.rb
+++ b/ruby-app/test/responses/my_elo_test.rb
@@ -71,21 +71,21 @@ class MyEloTest < Minitest::Test
   def test_slack_title_empty
     VCR.use_cassette('slack_title_empty') do
       response = @xander.respond_to("my elo #{@bot}", @user)
-      assert_equal "Hi <@#{@user}> I don't know your gamertag. Your profile title on slack is empty. Visit https://testing.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)", response.text
+      assert_response "Hi #{@user}! I don't know your gamertag. Your profile title on slack is empty. Visit https://testing.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)", response.text
     end
   end
 
   def test_slack_title_wrong_format
     VCR.use_cassette('slack_title_wrong_format') do
       response = @xander.respond_to("#{@bot} my elo", @user)
-      assert_equal "Hi <@U0TUWEY6R> I don't know your gamertag. Your profile title on slack is `wpp31`. Visit https://testing.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)", response.text
+      assert_response "Hi <@U0TUWEY6R>! I don't know your gamertag. Your profile title on slack is `wpp31`. Visit https://testing.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)", response.text
     end
   end
 
   def test_gg_membership_failed
     VCR.use_cassette('gg_membership_failed') do
       response = @xander.respond_to('<@botid> my elo', @user)
-      assert_equal "Hi <@U0TUWEY6R> I couldn’t find you on guardian.gg. Make sure your gamertag is correct.", response.text
+      assert_response "Hi <@U01TUWEY6R>! I couldn’t find you on guardian.gg. Make sure your gamertag is correct.", response.text
     end
   end
 

--- a/ruby-app/test/responses/my_elo_test.rb
+++ b/ruby-app/test/responses/my_elo_test.rb
@@ -64,7 +64,7 @@ class MyEloTest < Minitest::Test
   def test_slack_profile_empty
     VCR.use_cassette('slack_profile_empty') do
       response = @xander.respond_to("my elo #{@bot}", @user)
-      assert_equal "Hi <@#{@user}> I can't get your gamertag. Please add a profile title. Visit https://testing.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)", response.text
+      assert_response "Hi <@#{@user}>! I can't get your gamertag. Please add a profile title. Visit https://testing.slack.com/account/profile, click 'Edit' and change it in the 'What I do section'. (`PSN: yourgamertag` or `XB1: yourgamertag`)", response.text
     end
   end
 

--- a/ruby-app/test/test_helper.rb
+++ b/ruby-app/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'vcr'
 require 'minitest/autorun'
 require 'mocha/mini_test'
 require 'webmock/minitest'
+require 'custom_assertions'
 require 'byebug'
 require 'slack'
 


### PR DESCRIPTION
I wanted to test out having randomized greetings from Xander – this PR adds a few extra options when Xander comes back with a response to a query. Now when he says "Hi <username>", he will randomly pick a greeting to use, like "Howdy <username>".

I wanted to abstract out the repetitive parts of response messages so that each response object did not have to worry about it themselves.

This is open as an initial discussion, but I will migrate the remaining responses tomorrow.
